### PR TITLE
Migrate to Dropbox API v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,35 @@
 language: php
 
-sudo: false
-
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
 matrix:
-  include:
-    - php: 5.6
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    include:
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: nightly
+        - php: hhvm-3.6
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.9
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.12
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-3.15
+          sudo: required
+          dist: trusty
+          group: edge
+        - php: hhvm-nightly
+          sudo: required
+          dist: trusty
+          group: edge
+    fast_finish: true
+    allow_failures:
+        - php: nightly
+        - php: hhvm-nightly
 
 before_script:
   - travis_retry composer self-update
@@ -23,5 +41,5 @@ script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ To install, use composer:
 composer require stevenmaguire/oauth2-dropbox
 ```
 
+**Note:** Due API deprecation, we dropped support to Dropbox API v1. If you need use v1, please use `^2.0.0` version constraint:
+
+```
+composer require "stevenmaguire/oauth2-dropbox:^2.0.0"
+```
+
 ## Usage
 
 Usage is the same as The League's OAuth client, using `\Stevenmaguire\OAuth2\Client\Provider\Dropbox` as the provider.

--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -15,7 +15,7 @@ class Dropbox extends AbstractProvider
     /**
      * @var string Key used in the access token response to identify the resource owner.
      */
-    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'uid';
+    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'account_id';
 
     /**
      * Get authorization url to begin OAuth flow
@@ -24,7 +24,7 @@ class Dropbox extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return 'https://www.dropbox.com/1/oauth2/authorize';
+        return 'https://api.dropbox.com/oauth2/authorize';
     }
 
     /**
@@ -34,7 +34,7 @@ class Dropbox extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return 'https://api.dropbox.com/1/oauth2/token';
+        return 'https://api.dropbox.com/oauth2/token';
     }
 
     /**
@@ -46,7 +46,7 @@ class Dropbox extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return 'https://api.dropbox.com/1/account/info';
+        return 'https://api.dropbox.com/2/users/get_current_account';
     }
 
     /**

--- a/src/Provider/DropboxResourceOwner.php
+++ b/src/Provider/DropboxResourceOwner.php
@@ -3,9 +3,11 @@
 namespace Stevenmaguire\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Tool\ArrayAccessorTrait;
 
 class DropboxResourceOwner implements ResourceOwnerInterface
 {
+    use ArrayAccessorTrait;
     /**
      * Raw response
      *
@@ -30,7 +32,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response['account_id'] ?: null;
+        return $this->getValueByKey($this->response,'account_id');
     }
 
     /**
@@ -40,7 +42,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->response['name']['display_name'] ?: null;
+        return $this->getValueByKey($this->response,'name.display_name');
     }
 
     /**

--- a/src/Provider/DropboxResourceOwner.php
+++ b/src/Provider/DropboxResourceOwner.php
@@ -32,7 +32,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->getValueByKey($this->response,'account_id');
+        return $this->getValueByKey($this->response, 'account_id');
     }
 
     /**
@@ -42,7 +42,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->getValueByKey($this->response,'name.display_name');
+        return $this->getValueByKey($this->response, 'name.display_name');
     }
 
     /**

--- a/src/Provider/DropboxResourceOwner.php
+++ b/src/Provider/DropboxResourceOwner.php
@@ -30,7 +30,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response['uid'] ?: null;
+        return $this->response['account_id'] ?: null;
     }
 
     /**
@@ -40,7 +40,7 @@ class DropboxResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->response['display_name'] ?: null;
+        return $this->response['name']['display_name'] ?: null;
     }
 
     /**


### PR DESCRIPTION
Since Dropbox deprecated API v1 last year and will shut down endpoints on 28th September, I'm proposing a new version for this Provider that authenticates using API v2 endpoints.

Some notes:

- The generated authorization token can be used on v1 end-points (Although it's useless in a few months)
- The `DropboxResourceOwner` keeps it's methods, but the `uid` now is `account_id`, and it contents (using method `toArray()`) changes to the same response format from API v2 [get_current_account](https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account)

So I suggest that it becomes a new major version to avoid eventual breaking changes