### PR TITLE
Fetch data using POST method

### DIFF
--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -95,6 +95,21 @@ class Dropbox extends AbstractProvider
     }
 
     /**
+     * Requests resource owner details.
+     *
+     * @param  AccessToken $token
+     * @return mixed
+     */
+    protected function fetchResourceOwnerDetails(AccessToken $token)
+    {
+        $url = $this->getResourceOwnerDetailsUrl($token);
+
+        $request = $this->getAuthenticatedRequest(self::METHOD_POST, $url, $token);
+
+        return $this->getParsedResponse($request);
+    }
+
+    /**
      * Builds the authorization URL.
      *
      * @param  array $options


### PR DESCRIPTION
AbstractProvider uses GET method by default. However, Dropbox API requires to fetch data using POST, so the following error is thrown after the user authorizes the app

`Stevenmaguire\OAuth2\Client\Provider\Dropbox->createResourceOwner('Error in call to API function "users/get_current_account": Your request's HTTP request method is "GET".  This function only accepts the HTTP request method "POST".', Object) (Line: 754)`