### PR TITLE
Fix authorization URL

### DIFF
--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -24,7 +24,7 @@ class Dropbox extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return 'https://api.dropbox.com/oauth2/authorize';
+        return 'https://www.dropbox.com/oauth2/authorize';
     }
 
     /**


### PR DESCRIPTION
From the [docs](https://www.dropbox.com/developers/documentation/http/documentation):

> Note: This is the only step that requires an endpoint on www.dropbox.com. All other API requests are done via api.dropboxapi.com, content.dropboxapi.com, or notify.dropboxapi.com.

Until recently it also worked with `api.dropbox.com` but this is seemingly no longer the case.